### PR TITLE
fix premature termination of line map dumping in readelf

### DIFF
--- a/src/readelf.c
+++ b/src/readelf.c
@@ -8751,7 +8751,7 @@ print_debug_line_section (Dwfl_Module *dwflmod, Ebl *ebl, GElf_Ehdr *ehdr,
       if (linep == lineendp)
 	{
 	  puts (_("\nNo line number statements."));
-	  return;
+	  continue;
 	}
 
       puts (_("\nLine number statements:"));


### PR DESCRIPTION
previously, when readelf encountered an empty line table
it terminated line map dumping. this patch causes it
to continue to look for the next line map.